### PR TITLE
added integrity check after model updates

### DIFF
--- a/addon/__init__.py
+++ b/addon/__init__.py
@@ -143,6 +143,7 @@ def update_adjectives():
 
     adj_model_name = config.adjective_model_name()
     add_or_update_adjective_model(mw.col.models, adj_model_name)
+    mw.col.fix_integrity()
     dest_model = mw.col.models.by_name(adj_model_name)
     deck_updater = DeckUpdater(mw.col, target_deck_id, dest_model, config)
 
@@ -192,6 +193,7 @@ def update_verbs():
 
     verb_model_name = config.verb_model_name()
     add_or_update_verb_model(mw.col.models, verb_model_name)
+    mw.col.fix_integrity()
     dest_model = mw.col.models.by_name(verb_model_name)
     deck_updater = DeckUpdater(mw.col, target_deck_id, dest_model, config)
 

--- a/anki_jpn/decks.py
+++ b/anki_jpn/decks.py
@@ -70,7 +70,7 @@ class DeckUpdater: # pylint: disable=R0903
         reading = source_note.fields[source_fields[relevant_fields[2]][0]].split('<')[0].strip()
 
         query = f'"Expression:{expression}" "Meaning:{meaning}"' + \
-            f' "Reading:{reading}" "deck:{self._deck["name"]}" mid:{self._model_id}'
+            f' "Reading:{reading}" "deck:{self._deck["name"]}" "mid:{self._model_id}"'
         existing_notes = self._col.find_notes(query)
         if existing_notes:
             note = self._col.get_note(existing_notes[0])


### PR DESCRIPTION
The deck updater was failing to detect the existing cards in the deck after the model had been updated. The solution was to run an integrity check on the collection database. We were unable to reproduce in unit testing.